### PR TITLE
Route to check printer api response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ source 'https://rubygems.org'
 gem 'rake', '~> 10.5.0'
 gem 'sinatra', '~> 1.4.4', require: 'sinatra/base'
 
+group :test, :development do
+  gem 'rack-test', require: false
+  gem 'minitest'
+end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    minitest (5.9.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
     rake (10.5.0)
     sinatra (1.4.7)
       rack (~> 1.5)
@@ -15,6 +18,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  minitest
+  rack-test
   rake (~> 10.5.0)
   sinatra (~> 1.4.4)
 

--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require_relative './app/routes'
 module Doktor
   class App < Sinatra::Base
     use Routes::Core
+    use Routes::PrinterAPI
   end
 end
 

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -1,5 +1,6 @@
 module Doktor
   module Routes
     autoload :Core, './app/routes/core'
+    autoload :PrinterAPI, './app/routes/printer_api'
   end
 end

--- a/app/routes/printer_api.rb
+++ b/app/routes/printer_api.rb
@@ -1,0 +1,9 @@
+module Doktor
+  module Routes
+    class PrinterAPI < Core
+      get '/printer/:name/check/response' do |name|
+        "valid route for fulfiller #{name}"
+      end
+    end
+  end
+end

--- a/test/routes/printer_api_test.rb
+++ b/test/routes/printer_api_test.rb
@@ -1,0 +1,14 @@
+require_relative './routes_helper'
+
+class AppRoutesPrinterAPITest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Doktor::App
+  end
+
+  def test_response_code_for_fulfiller
+    get '/printer/cgx/check/response'
+    assert_equal 200, last_response.status
+  end
+end

--- a/test/routes/routes_helper.rb
+++ b/test/routes/routes_helper.rb
@@ -1,0 +1,8 @@
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+require 'rack/test'
+require 'sinatra/base'
+
+require_relative '../../app/routes/'
+require_relative '../../app'


### PR DESCRIPTION
This adds a test for a new route to check the repsonse code of a call to
the printer api endpoint for a valid fulfiller.

This is just the skeleton for the creation of the route. There is no
logic in the route yet but this just sets up the test and Rakefile to
allow running of the tests.
